### PR TITLE
Revert "fix cifs sidebar not showing"

### DIFF
--- a/luci-app-cifs-mount/luasrc/controller/cifs.lua
+++ b/luci-app-cifs-mount/luasrc/controller/cifs.lua
@@ -6,5 +6,5 @@ function index()
 		return
 	end
 	
-	entry({"admin", "services", "cifs"}, cbi("cifs"), _("Mount NetShare")).dependent = true
+	entry({"admin", "nas", "cifs"}, cbi("cifs"), _("Mount NetShare")).dependent = true
 end


### PR DESCRIPTION
This reverts commit c981d79a49392b28d332e41732854302bd84ad03.

移动luci-app-cifs的菜单到nas
